### PR TITLE
Add ssp extension to HTML syntax for SuiteCommerceAdvance

### DIFF
--- a/User/HTML.sublime-settings
+++ b/User/HTML.sublime-settings
@@ -1,0 +1,6 @@
+{
+	"extensions":
+	[
+		"ssp"
+	]
+}


### PR DESCRIPTION
This is created when opening a file with the .ssp extendion and then choosing View > Syntax > Open all with current extension as... HTML