### PR TITLE
Venda tags syntax highlighting fix

### DIFF
--- a/HTML/HTML.tmLanguage
+++ b/HTML/HTML.tmLanguage
@@ -512,7 +512,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;/?)([a-zA-Z0-9:]+)</string>
+			<string>(&lt;/?)([a-zA-Z0-9:_]+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -896,7 +896,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?&lt;='|")</string>
+			<string>(?&lt;==|='|=")</string>
 			<key>name</key>
 			<string>meta.attribute-with-value.id.html</string>
 			<key>patterns</key>


### PR DESCRIPTION
2 things was changed:
1. Regex to handle *\<venda_tags\>* (tags with underscore chars)
2. Value of *id* attribute without quotes now recognizes as a correct one

As the result sublime HTML syntax highlighter works with *\<venda_tags\>* the same way as with native HTML tags